### PR TITLE
修复recyclerView.getViewTreeObserver().removeOnGlobalLayoutListener(thi…

### DIFF
--- a/indicator/src/main/java/com/jiang/android/indicatordialog/IndicatorDialog.java
+++ b/indicator/src/main/java/com/jiang/android/indicatordialog/IndicatorDialog.java
@@ -124,7 +124,11 @@ public class IndicatorDialog {
             @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN)
             @Override
             public void onGlobalLayout() {
-                recyclerView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+                    recyclerView.getViewTreeObserver().removeOnGlobalLayoutListener(this);
+                } else {
+                    recyclerView.getViewTreeObserver().removeGlobalOnLayoutListener(this);
+                }
                 int recyclerviewHeight = recyclerView.getHeight();
                 resizeHeight(recyclerviewHeight);
             }


### PR DESCRIPTION
修复recyclerView.getViewTreeObserver().removeOnGlobalLayoutListener(this)在Android4.2以下设备崩溃的问题